### PR TITLE
update to match ledger app, SDK update, Sepculos emulator

### DIFF
--- a/lib/apdu/io.js
+++ b/lib/apdu/io.js
@@ -261,8 +261,7 @@ class APDUReader extends IOBuffer {
 
     // 3 bytes CHANNEL_ID and TAG_APDU
     // 2 bytes message sequence
-    //   (if sequence > 0, there is no additional 2 bytes message length)
-    // 2 bytes status code
+    // 2 bytes message length
     this.enforce(message.length >= 3 + 2 + 2, 'Incorrect message length');
     this.enforce(this.finished !== true, 'Reading from finished reader');
 

--- a/lib/apdu/io.js
+++ b/lib/apdu/io.js
@@ -259,7 +259,11 @@ class APDUReader extends IOBuffer {
   readFirstMessage(message) {
     const br = bufio.read(message);
 
-    this.enforce(message.length >= 7 + 5, 'Incorrect message length');
+    // 3 bytes CHANNEL_ID and TAG_APDU
+    // 2 bytes message sequence
+    //   (if sequence > 0, there is no additional 2 bytes message length)
+    // 2 bytes status code
+    this.enforce(message.length >= 3 + 2 + 2, 'Incorrect message length');
     this.enforce(this.finished !== true, 'Reading from finished reader');
 
     const channelID = br.readU16BE();

--- a/lib/device/speculos.js
+++ b/lib/device/speculos.js
@@ -1,0 +1,133 @@
+'use strict';
+
+const net = require('net');
+
+class USB {
+  constructor() {}
+
+  static getDevices() {
+    return [new exports.USBDevice()];
+  }
+
+  static requestDevice() {
+    return new exports.USBDevice();
+  }
+}
+
+class USBDevice {
+  constructor() {
+    this.vendorId = 0x2c97;
+    this.opened = false;
+    this.configuration = {};
+    this.socket;
+    this.host = '127.0.0.1';
+    this.port = 9999;
+    this.buffer = [];
+    this.left = 0;
+  }
+
+  open() {
+    this.opened = true;
+    this.socket = net.connect(
+      this.port,
+      this.host
+    );
+
+    this.socket.on('data', (data) => {
+      this.parseData(data);
+    });
+  }
+
+  close() {
+    this.socket.destroy();
+    this.opened = false;
+  }
+
+ parseData(data) {
+    function prefix(data, sequence) {
+      let inserted = 3;
+      if (sequence > 0)
+        inserted += 2;
+
+      const prefixed = Buffer.alloc(inserted + data.length);
+
+      // Prefix the CHANNEL_ID and TAG_APDU
+      prefixed[0] = 0x01;
+      prefixed[1] = 0x01;
+      prefixed[2] = 0x05;
+      data.copy(prefixed, inserted);
+
+      if (sequence > 0)
+        prefixed.writeUInt16BE(sequence, 3);
+
+      return prefixed;
+    }
+
+    // Bump packet size to include status message because
+    // Speculos decrements it for some reason:
+    // https://github.com/LedgerHQ/speculos/blob/
+    //   dce04843ad7d4edbcd399391b3c39d30b37de3cd/mcu/apdu.py#L81
+    let size = data.readUInt16BE(2);
+    size += 2;
+    data.writeUInt16BE(size, 2);
+
+    // Client expects chunks of 64 bytes
+    let sequence = 0;
+    while (data.length > 0) {
+      data = prefix(data, sequence++);
+      this.buffer.push(data.slice(0, 64));
+      data = data.slice(64);
+    }
+  }
+
+  async transferOut(endpointNumber, data) {
+    // Trim CHANNEL_ID (0x0101) and TAG_APDU (0x05)
+    data = data.slice(3);
+
+    // Remove non-zero sequence values after first chunk since Speculos
+    // only expects a 4-byte size
+    const sequence = data.readUInt16BE(0);
+    if (sequence > 0)
+      data = data.slice(2);
+
+    return this.socket.write(data);
+  }
+
+  async transferIn(endpointNumber, packetSize) {
+    // Message has already arrived, return it.
+    if (this.buffer.length > 0) {
+      return {
+        status: 'ok',
+        data: {buffer: this.buffer.shift()}
+      };
+    }
+
+    // Otherwise, wait.
+    return new Promise((resolve, reject) => {
+      this.socket.once('data', (data) => {
+        resolve({
+          status: 'ok',
+          data: {buffer: this.buffer.shift()}
+        });
+      });
+    });
+  }
+
+  reset() {}
+  claimInterface() {}
+  selectConfiguration() {}
+  releaseInterface() {}
+}
+
+class USBConfiguration {}
+class USBInterface {}
+class USBAlternateInterface {}
+class USBEndpoint {}
+
+exports.usb = USB;
+exports.USB = USB;
+exports.USBDevice = USBDevice;
+exports.USBConfiguration = USBConfiguration;
+exports.USBInterface = USBInterface;
+exports.USBAlternativeInterface = USBAlternateInterface;
+exports.USBEndpoint = USBEndpoint;

--- a/lib/device/usb.js
+++ b/lib/device/usb.js
@@ -8,9 +8,15 @@
 
 'use strict';
 
+let busb;
+
+if (process.env.SPECULOS === 'true')
+  busb = require('./speculos');
+else
+  busb = require('busb');
+
 const assert = require('bsert');
 const Logger = require('blgr');
-const busb = require('busb');
 const {Lock} = require('bmutex');
 const DeviceError = require('../device/error');
 const APDU = require('../apdu');

--- a/test/device/general.js
+++ b/test/device/general.js
@@ -65,7 +65,7 @@ module.exports = function (Device) {
     describe('getAppVersion()', () => {
       it('should return version', async () => {
         const got = await ledger.getAppVersion();
-        const want = '1.0.2';
+        const want = '1.0.4';
 
         assert.strictEqual(got, want, 'version mismatch');
       });
@@ -284,6 +284,9 @@ module.exports = function (Device) {
 
     for (const coin of coins)
       value += coin.value;
+
+    // Require a change output
+    value -= parseInt(value / 10);
 
     mtx.addOutput({ value, address });
 

--- a/test/device/general.js
+++ b/test/device/general.js
@@ -65,7 +65,7 @@ module.exports = function (Device) {
     describe('getAppVersion()', () => {
       it('should return version', async () => {
         const got = await ledger.getAppVersion();
-        const want = '1.0.0';
+        const want = '1.0.2';
 
         assert.strictEqual(got, want, 'version mismatch');
       });

--- a/test/device/hsd-test.js
+++ b/test/device/hsd-test.js
@@ -31,7 +31,7 @@ async function createLedgerChange(util, wid, mtx) {
   });
 }
 
-describe('Ledger Nano S', function() {
+describe('Ledger Nano S / Nano X', function() {
   this.timeout(60000);
 
   const util = new TestUtil();

--- a/test/device/sighash-test.js
+++ b/test/device/sighash-test.js
@@ -14,6 +14,7 @@ const {
   USB, LedgerHSD, LedgerChange, LedgerCovenant, LedgerInput
 } = require('../..');
 const {Device} = USB;
+const LOG_LEVEL = process.env.LOG_LEVEL || 'info';
 
 const network = Network.get('regtest');
 
@@ -29,7 +30,7 @@ describe('Sighash types support', function() {
     // Create logger.
     logger = new Logger({
       console: true,
-      level: 'info'
+      level: LOG_LEVEL
     });
 
     // Get first device available and set optional properties.


### PR DESCRIPTION
See https://github.com/handshake-org/ledger-app-hns/pull/8 for more details.

- Updates expected app version to `1.0.2`
- Checks env variable `LOG_LEVEL` in sighash test
- Fixes message length assertion (? -- one of those "how did this ever work before" mysteries...)
- Biggest change: adds Speculos module to route all messages to the emulator via TCP.

Activate the Speculos bridge by running the test with env variable:

```
export SPECULOS=true
```