### PR TITLE
pkg: remove peerDependency hsd

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ $ npm install
 
 ### Node.js Library
 
+When requiring `hsd-ledger` as a dependency in your project, you MUST
+also install `hsd`, either globally (`npm i -g hsd`) or require `hsd` as a
+sibling dependency along side `hsd-ledger`. This is effectively how
+`peerDependencies` worked in npm version 4 through 6, but starting with npm v7,
+those dependencies are installed, usually a second time, causing `instanceof`
+checks to fail.
+
 There are two ways to use this library to interact with a Ledger device:
 - using HID from Node.js
 - using WebUSB in the browser

--- a/package.json
+++ b/package.json
@@ -42,14 +42,10 @@
     "bufio": "git+https://github.com/bcoin-org/bufio#semver:^1.0.6",
     "node-hid": "git+https://github.com/nodech/node-hid#semver:2.1.1-hsd.0"
   },
-  "peerDependencies": {
-    "hsd": "git+https://github.com/handshake-org/hsd#semver:^2.1.5"
-  },
   "devDependencies": {
     "bmocha": "git+https://github.com/bcoin-org/bmocha#semver:^2.1.3",
-    "bpkg": "git+https://github.com/chjj/bpkg#semver:^0.6.0",
     "hs-client": "git+https://github.com/handshake-org/hs-client#semver:^0.0.8",
-    "hsd": "git+https://github.com/handshake-org/hsd#semver:^2.1.5"
+    "hsd": "git+https://github.com/handshake-org/hsd#semver:^3.0.1"
   },
   "engines": {
     "node": ">=8.0.0"


### PR DESCRIPTION
peerDeps don't mean what they used to... npm >= 7 will install hsd (a second time) for hsd-ledger which can cause `instanceof` checks to fail. "Assuming" the parent package already has hsd installed means there is only one hsd in the system and all `Input` objects are the came class.